### PR TITLE
Update version file based on forum thread

### DIFF
--- a/LaserDist.version
+++ b/LaserDist.version
@@ -10,12 +10,12 @@
   },
   "VERSION": {
     "MAJOR": 1,
-    "MINOR": 0,
-    "PATCH": 1
+    "MINOR": 1,
+    "PATCH": 0
   },
   "KSP_VERSION": {
     "MAJOR": 1,
-    "MINOR": 3,
-    "PATCH": 0
+    "MINOR": 4,
+    "PATCH": 5
   }
 }

--- a/LaserDist.version
+++ b/LaserDist.version
@@ -11,21 +11,11 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 0,
-    "PATCH": 0
+    "PATCH": 1
   },
   "KSP_VERSION": {
     "MAJOR": 1,
-    "MINOR": 2,
-    "PATCH": 2
-  },
-  "KSP_VERSION_MIN": {
-    "MAJOR": 1,
-    "MINOR": 1,
+    "MINOR": 3,
     "PATCH": 0
-  },
-  "KSP_VERSION_MAX": {
-    "MAJOR": 99,
-    "MINOR": 99,
-    "PATCH": 99
   }
 }


### PR DESCRIPTION
This mod's .version file currently announces compatibility with KSP 1.1.0–99.99.99, but that doesn't appear to be accurate. The forum thread regularly features reports of crashes after new game versions are released, followed by new recompiled releases (e.g., the latest release is entitled, "Recompile for KSP 1.3").

This pull request updates the .version file to reflect the apparent actual compatibility of the latest release, 1.3.0 only. This will help users of KSP-AVC, CKAN, and any other tools that parse .version files to avoid installing incompatible mod versions.

Fixes #22.